### PR TITLE
Ability to override the Vagrant box name

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,4 +1,4 @@
-VAGRANT_BOX_NAME = 'trusty64'
+VAGRANT_BOX_NAME = ENV['BOX_NAME']
 
 Vagrant.configure('2') do |config|
   config.cache.auto_detect = false

--- a/go.sh
+++ b/go.sh
@@ -2,8 +2,9 @@
 
 set -e
 
+export BOX_NAME=${BOX_NAME:-trusty64}   
+
 # Parallel spawning of virtual machines won't work for Parallels
 # See https://github.com/Parallels/vagrant-parallels/issues/148
 vagrant up --no-provision --no-parallel
 vagrant provision controller
-


### PR DESCRIPTION
This is useful for those using boxes with a different name
(e.g ubuntu/trusty64).
