### PR TITLE
Ignore host keys after env rebuild

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+host_key_checking=False


### PR DESCRIPTION
After rebuilding the vagrant env, the rc scripts under scripts/ will fail
to return the controller's IP, due to ssh failures with the ansible command.
