### PR TITLE
Beginnings of acceptance tests

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -134,3 +134,6 @@
       vncserver_proxy_address: "{{ hostvars['controller'].ansible_eth1.ipv4.address }}"
       my_ip: "{{ ansible_eth1.ipv4.address }}"
       #virt_type: qemu
+
+- name: Include acceptance tests
+  include: tests/main.yml

--- a/tests/main.yml
+++ b/tests/main.yml
@@ -1,0 +1,8 @@
+---
+- hosts: localhost
+  sudo: no
+  vars:
+    test_admin_rc: ../scripts/openstack-admin-example.rc
+    test_demo_rc: ../scripts/openstack-demo-example.rc
+  tasks:
+    - include: test_apis.yml

--- a/tests/test_apis.yml
+++ b/tests/test_apis.yml
@@ -1,0 +1,15 @@
+---
+- local_action: shell source {{ test_admin_rc }}
+
+- local_action: shell {{ item.command }} {{ item.subcommand }}
+  register: test_api
+  with_items:
+    - { command: 'nova', subcommand: 'list' }
+    - { command: 'glance', subcommand: 'image-list' }
+    - { command: 'neutron', subcommand: 'net-list' }
+    
+- name: ensure {{ item.cmd }} was successful
+  assert:
+    that:
+      - "{{ item.rc }} == 0"
+  with_items: test_api.results


### PR DESCRIPTION
Added a couple of basic tests to ensure the `nova`, `glance`, and `neutron`
apis are functioning.  Would like to build a decent set of tests that execute
after deployment.  This can help us catch things quickly as we develop.